### PR TITLE
add support for schema patterns with glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TypeScript d.ts file generator for JSON Schema file
 ```
 $ dtsgen --help
 
-  Usage: dtsgen [options] <file ...>
+  Usage: dtsgen [options] <file ... | file patterns using node-glob>
 
   Options:
 
@@ -28,3 +28,4 @@ $ dtsgen --help
 ## Example
 
     dtsgen --out types.d.ts schema1.json schema2.json
+    dtsgen --out types.d.ts schema/**/*.schema.json

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -15,7 +15,7 @@ var pkg = require("../package.json");
 // <hoge> is reuired, [hoge] is optional
 program
   .version(pkg.version)
-  .usage('[options] <file ...>')
+  .usage('[options] <file ... | file patterns using node-glob>')
   .option("-o, --out [file]", "output d.ts filename")
   .parse(process.argv);
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -5,6 +5,7 @@ import path = require("path");
 import program = require("commander");
 import mkdirp = require("mkdirp");
 var asyncblock = require("asyncblock");
+var glob = require('glob');
 
 import dtsgenerator = require("./index");
 
@@ -34,7 +35,10 @@ if (opts.args.length === 0) {
 function processGenerate(): void {
   asyncblock((flow: any) => {
     opts.args.forEach((arg) => {
-      fs.readFile(arg, { encoding: 'utf-8' }, flow.add(arg));
+      var files = glob.sync(arg);
+      files.forEach((file: any) => {
+        fs.readFile(file, {encoding: 'utf-8'}, flow.add(file));
+      });
     });
     var contents = flow.wait();
     var schemas: dtsgenerator.model.IJsonSchema[] = Object.keys(contents).map((key) => contents[key]);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "coveralls": "^2.11.3",
     "del": "^1.2.0",
+    "glob": "^5.0.14",
     "gulp": "^3.8.10",
     "gulp-coveralls": "^0.1.4",
     "gulp-espower": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   "dependencies": {
     "asyncblock": "^2.1.23",
     "commander": "^2.5.0",
+    "glob": "^5.0.14",
     "json-pointer": "^0.3.0",
     "mkdirp": "^0.5.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.3",
     "del": "^1.2.0",
-    "glob": "^5.0.14",
     "gulp": "^3.8.10",
     "gulp-coveralls": "^0.1.4",
     "gulp-espower": "^0.10.0",


### PR DESCRIPTION
This PR makes it possible to use patterns to set the schema files

`bin/dtsgen -o types.d.ts schema/**/*.schema.json`