### PR TITLE
Support draft03 generation

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -135,7 +135,7 @@ class Generator {
     Object.keys(type.properties || {}).forEach((propertyName) => {
       var property = type.properties[propertyName];
       process.outputJSDoc(property.description);
-      if (type.required && type.required.indexOf(propertyName) < 0) {
+      if (type.required && typeof(property.required)!=="boolean" && type.required.indexOf(propertyName) < 0) {
         propertyName = propertyName + "?";
       }
       this.parseTypeProperty(process, propertyName, property);
@@ -158,6 +158,8 @@ class Generator {
   }
 
   private parseTypeProperty(process: Process, name: string, property: model.IJsonSchema, terminate = true): void {
+    if (!property)
+      return;
     if (property.allOf) {
       var schema: any = {};
       property.allOf.forEach((p) => {
@@ -213,7 +215,7 @@ class Generator {
       if (property.properties) {
         Object.keys(property.properties).forEach((propertyName) => {
           var nextProperty = property.properties[propertyName];
-          if (property.required && property.required.indexOf(propertyName) < 0) {
+          if (property.required && typeof(property.required)!=="boolean" && property.required.indexOf(propertyName) < 0) {
             propertyName = propertyName + "?";
           }
           this.parseTypeProperty(process, propertyName, nextProperty);
@@ -260,4 +262,3 @@ class Generator {
 }
 
 export = Generator;
-


### PR DESCRIPTION
- Fix a bug on null property
- Make draft03 "required" work in some way. Is not possible to have it supporte ts optional ? attribute, cause required default is different between draft03/04 but at least it generate the d.ts also on draft03,
without the ?. Better than nothing. 

What do you think about it? Why not integrate it?

Of course I can't update to draft 04 my sources...