### PR TITLE
Fix: resolve reference in `extends Array<T>`

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -149,7 +149,8 @@ class Generator {
     var name = this.getTypename(this._id);
     process.output("export interface I").output(name).output(" extends Array<");
     if (type.items.$ref) {
-      this.parseTypePropertyNamedType(process, "I" + type.items.$ref, type.items, false);
+      var itemsRef = this.searchRef(type.items.$ref);
+      this.parseTypePropertyNamedType(process, "I" + this.getTypename(itemsRef.id), type.items, false);
     } else {
       this.parseTypeProperty(process, null, type.items, false);
     }


### PR DESCRIPTION
Currently:

```
{
  "FooList": {
    "type": "array",
    "items": {
      "$ref": "#/definitions/Foo"
  }
}
```

=> `export interface IFooList extends Array<I/definitions/Foo#>`

Expected:

`export interface IFooList extends Array<IFoo>`