### PR TITLE
Added support for YAML input files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "commander": "^2.9.0",
     "debug": "^2.3.3",
     "glob": "^7.1.1",
+    "js-yaml": "^3.7.0",
     "mkdirp": "^0.5.1",
     "request": "^2.79.0"
   },
@@ -51,6 +52,7 @@
     "@types/mocha": "^2.2.33",
     "@types/power-assert": "^1.4.29",
     "@types/request": "0.0.33",
+    "@types/js-yaml": "3.5.28",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-preset-es2015": "^6.18.0",

--- a/src/jsonSchemaParser.ts
+++ b/src/jsonSchemaParser.ts
@@ -8,6 +8,7 @@ import * as JsonPointer from './jsonPointer';
 import { SchemaId } from './schemaid';
 import { TypeDefinition } from './typeDefinition';
 import { WriteProcessor } from './writeProcessor';
+import YAML  = require('js-yaml');
 
 const debug = Debug('dtsgen');
 
@@ -156,7 +157,11 @@ export class JsonSchemaParser {
                         reject(err);
                     } else {
                         try {
-                            resolve(JSON.parse(content));
+                            if(file.slice(-5).toLowerCase() === ".yaml"){
+                                resolve(YAML.safeLoad(content));
+                            }else{
+                                resolve(JSON.parse(content));
+                            }
                         } catch (e) {
                             reject(e);
                         }
@@ -174,7 +179,11 @@ export class JsonSchemaParser {
                     return reject(body);
                 } else {
                     try {
-                        resolve(JSON.parse(body));
+                        if(url.slice(-5).toLowerCase() === ".yaml"){
+                            resolve(YAML.safeLoad(body));
+                        }else{
+                            resolve(JSON.parse(body));
+                        }
                     } catch (e) {
                         reject(e);
                     }


### PR DESCRIPTION
Ironically, I find YAML far superior for creating JSON-schema for it's relative ease of reading and editing.   This PR adds support for YAML input files by using the safeLoad method of [`js-yaml`](https://www.npmjs.com/package/js-yaml) package to load files ending in '.yaml'.