### PR TITLE
Improve message in error log

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ export function toTSType(type: string, debugSource?: any): string {
             return null;
         default:
             if (debugSource) {
-                console.error('  debugSource=' + debugSource);
+                console.error('  debugSource=' + JSON.stringify(debugSource, null, 2));
             }
             throw new Error('unknown type: ' + type);
     }


### PR DESCRIPTION
Prints error as JSON instead of just `[object Object]`.

Before:

```
  debugSource=[object Object]
Error: unknown type: /size
```

After:

```
  debugSource={
  "description": "Size in pixels of the image",
  "type": "/size"
}
Error: unknown type: /size
```

/cc @jasonreisman