### PR TITLE
fix: Create deep copy of schemes from allOf when they are merged

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,15 @@ import opts from './commandOptions';
 
 const debug = Debug('dtsgen');
 
+function deepCopy(value: any): any {
+    const json = JSON.stringify(value);
+    if (json) {
+        return JSON.parse(json);
+    } else {
+        return undefined;
+    }
+}
+
 export function toTSType(type: string, debugSource?: any): string {
     switch (type) {
         case 'integer':
@@ -54,18 +63,18 @@ export function toTypeName(str: string): string {
 export function mergeSchema(a: any, b: any): any {
     Object.keys(b).forEach((key: string) => {
         if (a[key] == null) {
-            a[key] = b[key];
+            a[key] = deepCopy(b[key]);
         } else {
             const value = b[key];
             if (typeof value !== typeof a[key]) {
                 debug(`mergeSchema warning: type is missmatched, key=${key}`);
-                a[key] = value;
+                a[key] = deepCopy(value);
             } else if (Array.isArray(value)) {
-                Array.prototype.push.apply(a[key], value);
+                Array.prototype.push.apply(a[key], deepCopy(value));
             } else if (typeof value === 'object') {
-                Object.assign(a[key], value);
+                Object.assign(a[key], deepCopy(value));
             } else {
-                a[key] = value;
+                a[key] = deepCopy(value);
             }
         }
     });

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -368,6 +368,63 @@ declare namespace Test {
 `;
         assert.equal(result, expected, result);
     });
+    it(' model in multiple allOf', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            definitions: {
+                Parent: {
+                    type: 'object',
+                    properties: {
+                        parent: {
+                            type: 'string',
+                        },
+                    },
+                },
+                FirstChild: {
+                    allOf: [
+                        { $ref: '#/definitions/Parent' },
+                        {
+                            type: 'object',
+                            properties: {
+                                first: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+                SecondChild: {
+                    allOf: [
+                        { $ref: '#/definitions/Parent' },
+                        {
+                            type: 'object',
+                            properties: {
+                                second: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Definitions {
+    export interface FirstChild {
+        parent?: string;
+        first?: string;
+    }
+    export interface Parent {
+        parent?: string;
+    }
+    export interface SecondChild {
+        parent?: string;
+        second?: string;
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
 
 });
 


### PR DESCRIPTION
Currently, when many schema is used multiple times in different allOf, it gets mutated each time.
Example schema:
```js
{
  definitions: {
    Parent: {
      type: 'object',
      properties: {
        parent: {
          type: 'string',
        },
      },
    },
    FirstChild: {
      allOf: [
        { $ref: '#/definitions/Parent' },
        {
          type: 'object',
          properties: {
            first: {
              type: 'string',
            },
          },
        },
      ],
    },
    SecondChild: {
      allOf: [
        { $ref: '#/definitions/Parent' },
        {
          type: 'object',
          properties: {
            second: {
              type: 'string',
            },
          },
        },
      ],
    },
  },
}
```
Generated d.ts:
```ts
declare namespace Definitions {
    export interface FirstChild {
        parent?: string;
        first?: string;
    }
    export interface Parent {
        parent?: string;
        first?: string;
    }
    export interface SecondChild {
        parent?: string;
        first?: string;
        second?: string;
    }
}
```
But the generated d.ts should be:
```ts
declare namespace Definitions {
    export interface FirstChild {
        parent?: string;
        first?: string;
    }
    export interface Parent {
        parent?: string;
    }
    export interface SecondChild {
        parent?: string;
        second?: string;
    }
}
```
This PR fixes it.