### PR TITLE
Prevent extended schema properties from leaking into base schema.

### DIFF
--- a/src/commandOptions.ts
+++ b/src/commandOptions.ts
@@ -1,4 +1,4 @@
-import { Command, ICommand } from 'commander';
+import { Command } from 'commander';
 
 /* tslint:disable:no-var-requires */
 const pkg = require('../package.json');
@@ -25,7 +25,7 @@ export class CommandOptions {
 let opts = new CommandOptions();
 clear(opts);
 
-export function initialize(argv?: string[]): ICommand | null {
+export function initialize(argv?: string[]) {
     if (argv) {
         return parse(opts, argv);
     } else {
@@ -46,7 +46,7 @@ function clear(o: CommandOptions): void {
     o.target = 'v2';
 }
 
-function parse(o: CommandOptions, argv: string[]): ICommand {
+function parse(o: CommandOptions, argv: string[]) {
     const command = new Command();
 
     function collectUrl(val: string, memo: string[]): string[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,14 @@ export function toTypeName(str: string): string {
 export function mergeSchema(a: any, b: any): any {
     Object.keys(b).forEach((key: string) => {
         if (a[key] == null) {
-            a[key] = b[key];
+            const value = b[key];
+            if (Array.isArray(value)) {
+                a[key] = value.slice();
+            } else if (typeof value === 'object') {
+                a[key] = Object.assign({}, value);
+            } else {
+                a[key] = value;
+            }
         } else {
             const value = b[key];
             if (typeof value !== typeof a[key]) {

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -368,6 +368,75 @@ declare namespace Test {
 `;
         assert.equal(result, expected, result);
     });
+    it ('should include allOf schemas', async () => {
+        const baseSchema: JsonSchemaOrg.Schema = {
+            id: 'http://test/zzz/allOf/base',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'string',
+                },
+            },
+            required: ['id'],
+        };
+        const extendedSchema: JsonSchemaOrg.Schema = {
+            id: 'http://test/zzz/allOf/extended',
+            type: 'object',
+            allOf: [
+                { $ref: '/zzz/allOf/base' },
+            ],
+            properties: {
+                value: {
+                    type: 'number',
+                },
+            },
+            required: ['value'],
+        };
+        const separateSchema: JsonSchemaOrg.Schema = {
+            id: 'http://test/separate',
+            type: 'object',
+            properties: {
+                message: {
+                    type: 'string',
+                },
+            },
+            required: ['message'],
+        };
+        const combinedSchema: JsonSchemaOrg.Schema = {
+            id: 'http://test/combined',
+            type: 'object',
+            allOf: [
+                { $ref: '/zzz/allOf/base' },
+                { $ref: '/zzz/allOf/extended' },
+                { $ref: '/separate' },
+            ],
+        };
 
+        const result = await dtsgenerator([baseSchema, extendedSchema, separateSchema, combinedSchema]);
+
+        const expected = `declare namespace Test {
+    export interface Combined {
+        id: string;
+        value: number;
+        message: string;
+    }
+    export interface Separate {
+        message: string;
+    }
+    namespace Zzz {
+        namespace AllOf {
+            export interface Base {
+                id: string;
+            }
+            export interface Extended {
+                value: number;
+                id: string;
+            }
+        }
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
 });
 


### PR DESCRIPTION
Resolves #226, where "base" schema interfaces were emitted with the properties of the "extended" schema due to a mutated, shared array.

Also includes a fix for a build error due to changes to the `commander` type definitions.