### PR TITLE
feat: support `minItems` on `tuple type`

### DIFF
--- a/src/typeDefinition.ts
+++ b/src/typeDefinition.ts
@@ -122,7 +122,7 @@ export class TypeDefinition {
     private generateTypeCollection(process: WriteProcessor, type: JsonSchemaOrg.Schema): void {
         const name = this.id.getInterfaceName();
         process.output('export type ').outputType(name).output(' = ');
-        this.generateArrayTypeProperty(process, type.items, true);
+        this.generateArrayTypeProperty(process, type.items, type.minItems, true);
     }
 
     private generateProperties(process: WriteProcessor, type: JsonSchemaOrg.Schema): void {
@@ -205,7 +205,7 @@ export class TypeDefinition {
         }
     }
 
-    private generateArrayTypeProperty(process: WriteProcessor, items: JsonSchemaOrg.Schema | JsonSchemaOrg.Schema[], terminate = true): void {
+    private generateArrayTypeProperty(process: WriteProcessor, items: JsonSchemaOrg.Schema | JsonSchemaOrg.Schema[], minItems = 0, terminate = true): void {
         if (!Array.isArray(items)) {
             this.generateTypeProperty(process, items == null ? {} : items, false);
             process.output('[]');
@@ -234,9 +234,10 @@ export class TypeDefinition {
             });
             process.output(']');
             schemas.pop();
-            if (schemas.length > 0) {
+            if (schemas.length > 0 && minItems <= items.length ) {
+                minItems++;
                 process.output(' | ');
-                this.generateArrayTypeProperty(process, schemas, terminate);
+                this.generateArrayTypeProperty(process, schemas, minItems, terminate);
             } else {
                 if (terminate) {
                     process.outputLine(';');
@@ -280,7 +281,7 @@ export class TypeDefinition {
                 process.outputLine(';');
             }
         } else if (type === 'array') {
-            this.generateArrayTypeProperty(process, property.items, terminate);
+            this.generateArrayTypeProperty(process, property.items, property.minItems, terminate);
         } else {
             throw new Error('unknown type: ' + property.type);
         }

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -138,6 +138,42 @@ declare namespace Test {
 `;
         assert.equal(result, expected, result);
     });
+    it('include tuple type schema minItems', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_items',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 3,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                        {
+                            type: 'string',
+                            enum: ['NW', 'NE', 'SW', 'SE'],
+                        },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinItems {
+        id?: number;
+        array?: [string, number, boolean, ("NW" | "NE" | "SW" | "SE")] | [string, number, boolean];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+
+
     it('all simple type schema', async () => {
         const schema: JsonSchemaOrg.Schema = {
             id: '/test/all_simple_type',


### PR DESCRIPTION
Hi there,

It's funny -- I woke up this morning planning to implement tuples support in dtsgenerator, because last night I noticed I was getting `any[]` where I was hoping for.... something more. :)

To my pleasant surprise, I had a brief moment of confusion followed by excitement when I discovered a passing test for a feature I was wanting but not getting from the pacakge. I guess you haven't published the tuple support to npm, yet.

In any case, my excitement ebbed slightly when I noticed that you'd implemented the tuples support properly -- that is to say that I think you have it right -- the spec allows for any cardinality to appear, the instance needn't have all of the members specified in the tuple. That makes for some ugliness in the typings code, as well as a pretty loose thingamabob from a type-safety standpoint.

So... minItems to the rescue. By respecting the minItems property, the explosion of variety in the tuples can be controlled, to the extent it is supposed to be controlled. 😆 

Thanks for the tuples support! It definitely made things easier than I thought they'd be today! Hope you like the minItems.

Cheers!