### PR TITLE
feat: minItems, maxItems for array tuples

### DIFF
--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -105,39 +105,6 @@ declare namespace Test {
             assert.equal(result, expected, result);
         }
     });
-    it('include tuple type schema', async () => {
-        const schema: JsonSchemaOrg.Schema = {
-            id: '/test/inc_tuple',
-            type: 'object',
-            properties: {
-                id: {
-                    type: 'integer',
-                },
-                array: {
-                    type: 'array',
-                    items: [
-                        { type: 'string' },
-                        { type: 'integer' },
-                        { type: 'boolean' },
-                        {
-                            type: 'string',
-                            enum: ['NW', 'NE', 'SW', 'SE'],
-                        },
-                    ],
-                },
-            },
-        };
-        const result = await dtsgenerator([schema]);
-
-        const expected = `declare namespace Test {
-    export interface IncTuple {
-        id?: number;
-        array?: [string, number, boolean, ("NW" | "NE" | "SW" | "SE")] | [string, number, boolean] | [string, number] | [string];
-    }
-}
-`;
-        assert.equal(result, expected, result);
-    });
     it('all simple type schema', async () => {
         const schema: JsonSchemaOrg.Schema = {
             id: '/test/all_simple_type',

--- a/test/tuple_test.ts
+++ b/test/tuple_test.ts
@@ -1,0 +1,318 @@
+import * as assert from 'power-assert';
+import dtsgenerator from '../src/';
+import { initialize } from '../src/commandOptions';
+
+describe('tuple test', () => {
+
+    afterEach(() => {
+        initialize();
+    });
+
+    it('include tuple type schema no min no max', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_no_min_no_max',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                        {
+                            type: 'string',
+                            enum: ['NW', 'NE', 'SW', 'SE'],
+                        },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleNoMinNoMax {
+        id?: number;
+        array?: [] | [string] | [string, number] | [string, number, boolean] | [string, number, boolean, ("NW" | "NE" | "SW" | "SE")] | [string, number, boolean, ("NW" | "NE" | "SW" | "SE"), any];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema min less than length', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_items_less_length',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 2,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinItemsLessLength {
+        id?: number;
+        array?: [string, number] | [string, number, boolean] | [string, number, boolean, any];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema min eql length', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_items_eql_length',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 3,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinItemsEqlLength {
+        id?: number;
+        array?: [string, number, boolean] | [string, number, boolean, any];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema min greater than length', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_items_greater_length',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 4,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinItemsGreaterLength {
+        id?: number;
+        array?: [string, number, boolean, Object] | [string, number, boolean, Object, any];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema max less than length', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_max_items_less_length',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    maxItems: 2,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMaxItemsLessLength {
+        id?: number;
+        array?: [] | [string] | [string, number];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema max eql length', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_max_items_eql_length',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    maxItems: 3,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMaxItemsEqlLength {
+        id?: number;
+        array?: [] | [string] | [string, number] | [string, number, boolean];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema max greater than length', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_max_items_greater_length',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    maxItems: 4,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMaxItemsGreaterLength {
+        id?: number;
+        array?: [] | [string] | [string, number] | [string, number, Object] | [string, number, Object, Object];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema min and max in length range', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_max_in_range',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 2,
+                    maxItems: 4,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinMaxInRange {
+        id?: number;
+        array?: [string, number] | [string, number, boolean] | [string, number, boolean, string];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema min and max exceeds range', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_max_in_range',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 2,
+                    maxItems: 6,
+                    items: [
+                        { type: 'string' },
+                        { type: 'integer' },
+                        { type: 'boolean' },
+                        { type: 'string' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinMaxInRange {
+        id?: number;
+        array?: [string, number] | [string, number, boolean] | [string, number, boolean, string] | [string, number, boolean, string, Object] | [string, number, boolean, string, Object, Object];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('include tuple type schema min greater than max never', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_min_max_never',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 3,
+                    maxItems: 2,
+                    items: [
+                        { type: 'string' },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleMinMaxNever {
+        id?: number;
+        array?: never;
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+});


### PR DESCRIPTION
This commit adds minItems and maxItems support for array tuples and breaks out tests for tuples to their own module.

Adopting this change will change the effective typings of tuples as compared to the prior commit. In particular, I believe the prior implementation was incorrect, in that it did not allow for extra elements to appear (i.e. what should have been unbounded wasn't).

Under this commit, tuples don't automagically become bounded at the number of items in the schema, but rather their length is determined by minItems and maxItems.

`any` at the end of an array literal results in such an array that goes to ...any[] at the end.

`Object` binds to everything except the absence of anything -- i.e.

`x: [ Object ] = [ undefined ]` is legitimate, thus making Object the right choice to demand there be an element without there being any demands on the element.

E.g.,
```javascript
    array: {
        type: 'array',
        maxItems: 2,
        items: [
            { type: 'string' },
            { type: 'integer' },
            { type: 'boolean' },
        ],
    },
```
yields
```typescript
  [] | [string] | [string, number]
```
and
```javascript
{
    array: {
        type: 'array',
        minItems: 3,
        items: [
            { type: 'string' },
            { type: 'integer' },
            { type: 'boolean' },
        ],
    },
}
```
yields
```typescript
    [string, number, boolean] | [string, number, boolean, any]
```
and
```javascript
    array: {
        type: 'array',
        minItems: 4,
        items: [
            { type: 'string' },
            { type: 'integer' },
            { type: 'boolean' },
        ],
    },
```
yields
```typescript
    [string, number, boolean, Object] | [string, number, boolean, Object, any]
```
and
```javascript
    array: {
        type: 'array',
        minItems: 2,
        maxItems: 4,
        items: [
            { type: 'string' },
            { type: 'integer' },
            { type: 'boolean' },
            { type: 'string' },
            { type: 'integer' },
            { type: 'boolean' },
        ],
    },
```
yields
```typescript
    [string, number] | [string, number, boolean] | [string, number, boolean, string]
```

If `minItems` is greater than `maxItems`, you may have complaints from other tools,
but just to add to them, the generator in such case will render the type:
```typescript
  never
```