### PR TITLE
fix: items.length === 0 yields any[], not []

### DIFF
--- a/src/typeDefinition.ts
+++ b/src/typeDefinition.ts
@@ -213,7 +213,7 @@ export class TypeDefinition {
                 process.outputLine(';');
             }
         } else if (items.length === 0) {
-            process.output('[]');
+            process.output('any[]');
             if (terminate) {
                 process.outputLine(';');
             }

--- a/test/tuple_test.ts
+++ b/test/tuple_test.ts
@@ -8,6 +8,32 @@ describe('tuple test', () => {
         initialize();
     });
 
+    it('no items', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_no_min',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    items: [
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleNoMin {
+        id?: number;
+        array?: any[];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
     it('no min', async () => {
         const schema: JsonSchemaOrg.Schema = {
             id: '/test/inc_tuple_no_min',


### PR DESCRIPTION
Argh. After figuring out that `[]` is definitely not valid TypeScript, I neglected to notice that the existing code handling the `items.length === 0` case was emitting just that.

This commit fixes that.
