### PR TITLE
fix: items.length === 0 cases in tuples

### DIFF
--- a/src/typeDefinition.ts
+++ b/src/typeDefinition.ts
@@ -205,24 +205,24 @@ export class TypeDefinition {
         }
     }
 
-    private generateArrayTypeProperty(process: WriteProcessor, items: JsonSchemaOrg.Schema | JsonSchemaOrg.Schema[], minItems = 0, terminate = true): void {
+    private generateArrayTypeProperty(process: WriteProcessor, items: JsonSchemaOrg.Schema | JsonSchemaOrg.Schema[], minItems?: number, terminate = true): void {
         if (!Array.isArray(items)) {
             this.generateTypeProperty(process, items == null ? {} : items, false);
             process.output('[]');
             if (terminate) {
                 process.outputLine(';');
             }
-        } else if (items.length === 0) {
-            process.output('[]');
+        } else if (items.length === 0 && minItems === undefined) {
+            process.output('any[]');
             if (terminate) {
                 process.outputLine(';');
             }
             return;
         } else {
             const schemas = items.concat();
-            const effectiveMaxItems = 1 + Math.max(minItems, schemas.length);
+            const effectiveMaxItems = 1 + Math.max(minItems || 0, schemas.length);
             for (
-                let unionIndex = minItems === 0 ? 1 : minItems;
+                let unionIndex = minItems === undefined ? 1 : minItems;
                 unionIndex <= effectiveMaxItems;
                 unionIndex++
             ) {

--- a/test/tuple_test.ts
+++ b/test/tuple_test.ts
@@ -131,4 +131,57 @@ describe('tuple test', () => {
 `;
         assert.equal(result, expected, result);
     });
+    it('items.length zero, no minItems', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_no_min',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    items: [
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleNoMin {
+        id?: number;
+        array?: any[];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it('items.length zero, with minItems', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: '/test/inc_tuple_no_min',
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                },
+                array: {
+                    type: 'array',
+                    minItems: 2,
+                    items: [
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export interface IncTupleNoMin {
+        id?: number;
+        array?: [Object, Object] | [Object, Object, any];
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
 });


### PR DESCRIPTION
If `items.length === 0 && minItems !== undefined`, yield tuples sufficient
to fill out minItems, e.g. if `minItems === 2`, yield `[Object, Object] | [Object, Object, any]`.

If `items.length === 0 && minItems === undefined`, yield `any[]`.