### PR TITLE
fix: missing properties in models from unresolved $refs

### DIFF
--- a/src/typeDefinition.ts
+++ b/src/typeDefinition.ts
@@ -71,6 +71,9 @@ export class TypeDefinition {
             base.allOf.forEach((p) => {
                 if (p.$ref) {
                     p = this.searchRef(process, p.$ref).targetSchema;
+                    if (p.allOf && p.allOf.some((allOfChild: JsonSchemaOrg.Schema) => !!allOfChild.$ref)) {
+                        p = this.checkSchema(process, p);
+                    }
                 }
                 utils.mergeSchema(schema, p);
             });

--- a/src/typeDefinition.ts
+++ b/src/typeDefinition.ts
@@ -71,9 +71,7 @@ export class TypeDefinition {
             base.allOf.forEach((p) => {
                 if (p.$ref) {
                     p = this.searchRef(process, p.$ref).targetSchema;
-                    if (p.allOf && p.allOf.some((allOfChild: JsonSchemaOrg.Schema) => !!allOfChild.$ref)) {
-                        p = this.checkSchema(process, p);
-                    }
+                    p = this.checkSchema(process, p);
                 }
                 utils.mergeSchema(schema, p);
             });

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -425,6 +425,122 @@ declare namespace Test {
 `;
         assert.equal(result, expected, result);
     });
+    it(' model in multiple allOf nested ordered $refs', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            definitions: {
+                Parent: {
+                    type: 'object',
+                    properties: {
+                        parent: {
+                            type: 'string',
+                        },
+                    },
+                },
+                FirstChild: {
+                    allOf: [
+                        { $ref: '#/definitions/Parent' },
+                        {
+                            type: 'object',
+                            properties: {
+                                first: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+                SecondChild: {
+                    allOf: [
+                        { $ref: '#/definitions/FirstChild' },
+                        {
+                            type: 'object',
+                            properties: {
+                                second: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Definitions {
+    export interface FirstChild {
+        parent?: string;
+        first?: string;
+    }
+    export interface Parent {
+        parent?: string;
+    }
+    export interface SecondChild {
+        parent?: string;
+        first?: string;
+        second?: string;
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
+    it(' model in multiple allOf nested unordered $refs', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            definitions: {
+                Parent: {
+                    type: 'object',
+                    properties: {
+                        parent: {
+                            type: 'string',
+                        },
+                    },
+                },
+                FirstChild: {
+                    allOf: [
+                        { $ref: '#/definitions/SecondChild' },
+                        {
+                            type: 'object',
+                            properties: {
+                                first: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+                SecondChild: {
+                    allOf: [
+                        { $ref: '#/definitions/Parent' },
+                        {
+                            type: 'object',
+                            properties: {
+                                second: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Definitions {
+    export interface FirstChild {
+        parent?: string;
+        second?: string;
+        first?: string;
+    }
+    export interface Parent {
+        parent?: string;
+    }
+    export interface SecondChild {
+        parent?: string;
+        second?: string;
+    }
+}
+`;
+        assert.equal(result, expected, result);
+    });
     it('should include allOf schemas', async () => {
         const baseSchema: JsonSchemaOrg.Schema = {
             id: 'http://test/zzz/allOf/base',


### PR DESCRIPTION
Please consider following example:
```
Parent
properties:
  parent

FirstChild
allOf:
- $ref: SecondChild.yaml
properties:
  first
 
SecondChild
allOf:
- $ref: Parent.yaml
properties:
  second
```

Current output model for this example is:
```
declare namespace Definitions {
    export interface FirstChild {
        first?: string;
    }
    ..
}
```
Correct output should be:
```
declare namespace Definitions {
    export interface FirstChild {
        parent?: string;
        second?: string;
        first?: string;
    }
    ..
}
```

During traversing definitions of types they are sorted alphabetically: 
```
jsonSchemaParser.ts:80     const keys = Object.keys(env).sort();
```

In our example the `FirstChild` will be the first type to walk through by the processor.
When `FirstChild` schema is merged with its $ref: `SecondChild` schema, target properties still contain unresolved $refs ($ref to `Parent` object).

Unfortunately there is no recursion during merging schemas.

My PR resolves this issue.