### PR TITLE
feat: type intersection option for `allOf` and `anyOf` schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.un~
 *.swp
 
+coverage/
 node_modules/
 .nyc_output/
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ dtsgen --help
     --stdin                            read stdin with other files or urls.
     -o, --out <file>                   output d.ts filename.
     -p, --prefix <type prefix>         set the prefix of interface name. default is nothing.
+    -i, --intersection                 output intersection types for `allOf` schema.
     -H, --header <type header string>  set the string of type header.
     -t, --target [version]             set target TypeScript version. select from `v2` or `v1`. default is `v2`.
     -h, --help                         output usage information

--- a/src/commandOptions.ts
+++ b/src/commandOptions.ts
@@ -15,6 +15,7 @@ export class CommandOptions {
     public prefix?: string;
     public header?: string;
     public target: TargetVersion = 'v2';
+    public intersection?: boolean;
 
     public isReadFromStdin(): boolean {
         return this.stdin || this.files.length === 0 && this.urls.length === 0;
@@ -38,6 +39,7 @@ export function clear(): void {
     opts.prefix = undefined;
     opts.header = undefined;
     opts.target = 'v2';
+    opts.intersection = undefined;
 }
 
 function parse(o: CommandOptions, argv: string[]) {
@@ -65,6 +67,7 @@ function parse(o: CommandOptions, argv: string[]) {
         .option('--stdin', 'read stdin with other files or urls.')
         .option('-o, --out <file>', 'output d.ts filename.')
         .option('-p, --prefix <type prefix>', 'set the prefix of interface name. default is nothing.')
+        .option('-i, --intersection', 'output intersection types for `allOf` and `anyOf` schema.')
         .option('-H, --header <type header string>', 'set the string of type header.')
         .option('-t, --target [version]', 'set target TypeScript version. select from `v2` or `v1`. default is `v2`.', /^(v?2|v?1)$/i, 'v2')
         .on('--help', () => {
@@ -87,6 +90,7 @@ function parse(o: CommandOptions, argv: string[]) {
     o.out = res.out;
     o.prefix = res.prefix;
     o.header = res.header;
+    o.intersection = res.arithmetic;
     o.target = normalize(res.target);
     return command;
 }

--- a/test/commandOptions_test.ts
+++ b/test/commandOptions_test.ts
@@ -33,6 +33,7 @@ describe('output command help test', () => {
     --stdin                            read stdin with other files or urls.
     -o, --out <file>                   output d.ts filename.
     -p, --prefix <type prefix>         set the prefix of interface name. default is nothing.
+    -i, --intersection                 output intersection types for \`allOf\` and \`anyOf\` schema.
     -H, --header <type header string>  set the string of type header.
     -t, --target [version]             set target TypeScript version. select from \`v2\` or \`v1\`. default is \`v2\`. (default: v2)
     -h, --help                         output usage information

--- a/test/expected_file/advanced_schema.d.ts
+++ b/test/expected_file/advanced_schema.d.ts
@@ -21,7 +21,7 @@ declare namespace SomeSiteSomewhere {
             export interface Nfs {
                 type: "nfs";
                 remotePath: string; // ^(/[^/]+)+$
-                server: any /* host-name */  | any /* ipv4 */  | any; // ipv6
+                server: any /* host-name */  | any /* ipv4 */  | any /* ipv6 */ ;
             }
             export interface Tmpfs {
                 type: "tmpfs";

--- a/test/intersection_test.ts
+++ b/test/intersection_test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'power-assert';
+import dtsgenerator from '../src/';
+import opts, { clear } from '../src/commandOptions';
+
+
+describe('intersection test', () => {
+
+    beforeEach(() => {
+        opts.intersection = true;
+    });
+
+    afterEach(() => {
+        clear();
+    });
+
+    it('should combine allOf and anyOf using intersection', async () => {
+        const schema: JsonSchemaOrg.Schema = {
+            id: 'http://test/intersection',
+            allOf: [
+                { anyOf: [
+                    { type: 'object', required: ['a'], properties: { a: { type: 'string' } } },
+                    { type: 'object', required: ['b'], properties: { b: { enum: ['one', 'two'] } } },
+                ]},
+                {
+                    required: ['c'],
+                    type: 'object',
+                    properties: {
+                        c:  { type: 'number'  },
+                    },
+                },
+            ],
+        };
+        const result = await dtsgenerator([schema]);
+
+        const expected = `declare namespace Test {
+    export type Intersection = ({
+        a: string;
+    } | {
+        b: "one" | "two";
+    }) & {
+        c: number;
+    };
+}
+`;
+        assert.equal(result, expected, result);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    "esModuleInterop": true,
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
A new option (`-i`/`--intersection`) enables output of [TypeScript intersection
types](https://www.typescriptlang.org/docs/handbook/advanced-types.html) for`allOf` and `anyOf` schema. Specifically, `allOf` schema are rendered as types
defined as, e.g. `A & B` and `anyOf` schema as `(A | B)` (the parentheses in
the latter to assert precedence).

As a byproduct of these changes, the rendering process now outputs "/* ..*/"
comments for the last enum value in the list, consistent with prior items in
the enum, whereas it had previously emitted the last comment in "//" style, and
so this change also includes a corresponding tweak to the test fixture in `advanced_schema.d.ts`.

@horiuchi -- I realize this probably seems like it's coming in from left field, because,
of course, it is. I've been using it in a project for a while, and it's been indispensable 
for rendering some rather complex schema. Hope you'll consider taking it into the repo.

Cheers,
Daphne 
