### PR TITLE
Apply feedback for 304

### DIFF
--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -197,7 +197,10 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             if (ops == null) {
                 return;
             }
-            // const operationId = ops.operationId;
+            const operationId = ops.operationId;
+            if (operationId) {
+                keys = [keys[0], operationId];
+            }
             setSubIdToParameters(ops.parameters, keys.concat('parameters'));
             setSubIdToResponsesV2(ops.responses, keys.concat('responses'));
         }
@@ -246,7 +249,10 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             if (ops == null) {
                 return;
             }
-            // const operationId = ops.operationId;
+            const operationId = ops.operationId;
+            if (operationId) {
+                keys = [keys[0], operationId];
+            }
             setSubIdToParameters(ops.parameters, keys.concat('parameters'));
             setSubIdToRequestBody(ops.requestBody, keys.concat('requestBody'));
             setSubIdToResponsesV3(ops.responses, keys.concat('responses'));

--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -1,11 +1,13 @@
 import * as JsonPointer from '../jsonPointer';
 import SchemaId from './schemaId';
+import { normalizeTypeName } from './typeNameConvertor';
 
 export type JsonSchema = JsonSchemaOrg.Draft04.Schema | JsonSchemaOrg.Draft07.Schema;
 export type JsonSchemaObject = JsonSchemaOrg.Draft04.Schema | JsonSchemaOrg.Draft07.SchemaObject;
 type OpenApiSchema = SwaggerIo.V2.SchemaJson | OpenApisOrg.V3.SchemaJson;
 
-type Parameter = { name: string; schema?: JsonSchemaObject; } | { $ref?: string; };
+interface ParameterObject { name: string; in: string; required?: boolean; schema?: JsonSchemaObject; }
+type Parameter = ParameterObject | { $ref?: string; };
 
 export type SchemaType = 'Draft04' | 'Draft07';
 
@@ -150,7 +152,7 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             return '#/' + paths.join('/');
         }
         function convertKeyToTypeName(key: string): string {
-            return key.replace(/[\/}]/g, '').replace(/{/, '$');
+            return normalizeTypeName(key.replace(/[\/}]/g, '').replace(/{/, '$'));
         }
         function setSubIdToAnyObject<T>(f: (t: T, keys: string[]) => void, obj: { [key: string]: T } | undefined, keys: string[]): void {
             if (obj == null) {
@@ -164,10 +166,7 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
 
         // for OpenAPI
         const setSubIdToParameterObject = (obj: { [name: string]: Parameter; } | undefined, keys: string[]) => setSubIdToAnyObject(setSubIdToParameter, obj, keys);
-        function setSubIdToParameter(param: Parameter | undefined, keys: string[]): void {
-            if (param == null) {
-                return;
-            }
+        function setSubIdToParameter(param: Parameter, keys: string[]): void {
             if ('schema' in param) {
                 setSubId(param.schema, keys.concat(param.name));
             }
@@ -176,9 +175,39 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             if (array == null) {
                 return;
             }
+            const map = new Map<string, ParameterObject[]>();
             array.forEach((item) => {
-                setSubIdToParameter(item, keys);
+                if ('schema' in item) {
+                    setSubIdToParameter(item, keys);
+
+                    let work = map.get(item.in);
+                    if (work == null) {
+                        work = [];
+                        map.set(item.in, work);
+                    }
+                    work.push(item);
+                }
             });
+            addParameterSchema(map, keys);
+        }
+        function addParameterSchema(input: Map<string, ParameterObject[]>, keys: string[]): void {
+            for (const [key, params] of input) {
+                const [paths, obj] = buildParameterSchema(key, params, keys);
+                setSubId(obj, paths);
+            }
+        }
+        function buildParameterSchema(inType: string, params: ParameterObject[], keys: string[]): [string[], JsonSchemaObject] {
+            const paths = keys.slice(0, keys.length - 1).concat(inType + 'Parameters');
+            const properties: any = {};
+            params.forEach((item) => {
+                properties[item.name] = { $ref: createId(keys.concat(item.name)) };
+            });
+            return [paths, {
+                id: createId(paths),
+                type: 'object',
+                properties,
+                required: params.filter((item) => item.required === true).map((item) => item.name),
+            }];
         }
 
         /// for OpenAPI V2 only
@@ -201,7 +230,7 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             }
             const operationId = ops.operationId;
             if (operationId) {
-                keys = [keys[0], operationId];
+                keys = [keys[0], convertKeyToTypeName(operationId)];
             }
             setSubIdToParameters(ops.parameters, keys.concat('parameters'));
             setSubIdToResponsesV2(ops.responses, keys.concat('responses'));
@@ -253,7 +282,7 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             }
             const operationId = ops.operationId;
             if (operationId) {
-                keys = [keys[0], operationId];
+                keys = [keys[0], convertKeyToTypeName(operationId)];
             }
             setSubIdToParameters(ops.parameters, keys.concat('parameters'));
             setSubIdToRequestBody(ops.requestBody, keys.concat('requestBody'));
@@ -290,11 +319,10 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
                 const schemaId = new SchemaId(s.$ref);
                 s.$ref = schemaId.getAbsoluteId();
                 onFoundReference(schemaId);
-            } else {
-                const id = createId(paths);
-                setId(schema.type, s, id);
-                walk(s, paths, []);
             }
+            const id = createId(paths);
+            setId(schema.type, s, id);
+            walk(s, paths, []);
         }
 
         if ('swagger' in openApi) {

--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -1,6 +1,5 @@
 import * as JsonPointer from '../jsonPointer';
 import SchemaId from './schemaId';
-import { normalizeTypeName } from './typeNameConvertor';
 
 export type JsonSchema = JsonSchemaOrg.Draft04.Schema | JsonSchemaOrg.Draft07.Schema;
 export type JsonSchemaObject = JsonSchemaOrg.Draft04.Schema | JsonSchemaOrg.Draft07.SchemaObject;
@@ -150,13 +149,16 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
         function createId(paths: string[]): string {
             return '#/' + paths.join('/');
         }
+        function convertKeyToTypeName(key: string): string {
+            return key.replace(/[\/}]/g, '').replace(/{/, '$');
+        }
         function setSubIdToAnyObject<T>(f: (t: T, keys: string[]) => void, obj: { [key: string]: T } | undefined, keys: string[]): void {
             if (obj == null) {
                 return;
             }
             Object.keys(obj).forEach((key) => {
                 const item = obj[key];
-                f(item, keys.concat(normalizeTypeName(key)));
+                f(item, keys.concat(convertKeyToTypeName(key)));
             });
         }
 

--- a/src/core/schemaConvertor.ts
+++ b/src/core/schemaConvertor.ts
@@ -189,6 +189,7 @@ export default class SchemaConvertor {
     }
     private getTypename(id: SchemaId, baseSchema: Schema): string[] {
         const result = this.convertor(id);
+        this.replaceNamespace(result);
         const baseId = baseSchema.id;
         if (baseId) {
             const baseTypes = this.convertor(baseId).slice(0, -1);
@@ -203,7 +204,6 @@ export default class SchemaConvertor {
                 return [this.getLastTypeName(id)];
             }
         }
-        this.replaceNamespace(result);
         return result;
     }
     public outputPrimitiveTypeName(schema: NormalizedSchema, typeName: string, terminate = true, outputOptional = true): void {

--- a/test/snapshots/openapi-v2/petstore-json/_expected.d.ts
+++ b/test/snapshots/openapi-v2/petstore-json/_expected.d.ts
@@ -14,9 +14,33 @@ declare namespace Definitions {
     }
 }
 declare namespace Paths {
+    namespace AddPet {
+        export interface BodyParameters {
+            pet: Parameters.Pet;
+        }
+        namespace Parameters {
+            export type Pet = Definitions.NewPet;
+        }
+        namespace Responses {
+            export type $200 = Definitions.Pet;
+            export type Default = Definitions.Error;
+        }
+    }
+    namespace DeletePet {
+        namespace Responses {
+            export type Default = Definitions.Error;
+        }
+    }
+    namespace FindPetById {
+        namespace Responses {
+            export type $200 = Definitions.Pet;
+            export type Default = Definitions.Error;
+        }
+    }
     namespace FindPets {
         namespace Responses {
             export type $200 = Definitions.Pet[];
+            export type Default = Definitions.Error;
         }
     }
 }

--- a/test/snapshots/openapi-v2/petstore-json/_expected.d.ts
+++ b/test/snapshots/openapi-v2/petstore-json/_expected.d.ts
@@ -14,11 +14,9 @@ declare namespace Definitions {
     }
 }
 declare namespace Paths {
-    namespace Pets {
-        namespace Get {
-            namespace Responses {
-                export type $200 = Definitions.Pet[];
-            }
+    namespace FindPets {
+        namespace Responses {
+            export type $200 = Definitions.Pet[];
         }
     }
 }

--- a/test/snapshots/openapi-v2/petstore/_expected.d.ts
+++ b/test/snapshots/openapi-v2/petstore/_expected.d.ts
@@ -14,9 +14,33 @@ declare namespace Definitions {
     }
 }
 declare namespace Paths {
+    namespace AddPet {
+        export interface BodyParameters {
+            pet: Parameters.Pet;
+        }
+        namespace Parameters {
+            export type Pet = Definitions.NewPet;
+        }
+        namespace Responses {
+            export type $200 = Definitions.Pet;
+            export type Default = Definitions.Error;
+        }
+    }
+    namespace DeletePet {
+        namespace Responses {
+            export type Default = Definitions.Error;
+        }
+    }
+    namespace FindPetById {
+        namespace Responses {
+            export type $200 = Definitions.Pet;
+            export type Default = Definitions.Error;
+        }
+    }
     namespace FindPets {
         namespace Responses {
             export type $200 = Definitions.Pet[];
+            export type Default = Definitions.Error;
         }
     }
 }

--- a/test/snapshots/openapi-v2/petstore/_expected.d.ts
+++ b/test/snapshots/openapi-v2/petstore/_expected.d.ts
@@ -14,11 +14,9 @@ declare namespace Definitions {
     }
 }
 declare namespace Paths {
-    namespace Pets {
-        namespace Get {
-            namespace Responses {
-                export type $200 = Definitions.Pet[];
-            }
+    namespace FindPets {
+        namespace Responses {
+            export type $200 = Definitions.Pet[];
         }
     }
 }

--- a/test/snapshots/openapi-v3/petstore-change-namespace/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-change-namespace/_expected.d.ts
@@ -1,32 +1,25 @@
 declare namespace Test {
     namespace PetStore {
-        namespace Delete {
-            namespace Parameters {
-                export type Id = number; // int64
-            }
-        }
         export interface Error {
             code: number; // int32
             message: string;
-        }
-        namespace Get {
-            namespace Parameters {
-                export type Id = number; // int64
-                export type Limit = number; // int32
-                export type Tags = string[];
-            }
-            namespace Responses {
-                export type $200 = Test.PetStore.Pet[];
-            }
         }
         export interface NewPet {
             name: string;
             tag?: string;
         }
+        namespace Parameters {
+            export type Id = number; // int64
+            export type Limit = number; // int32
+            export type Tags = string[];
+        }
         export interface Pet {
             name: string;
             tag?: string;
             id: number; // int64
+        }
+        namespace Responses {
+            export type $200 = Test.PetStore.Pet[];
         }
     }
 }

--- a/test/snapshots/openapi-v3/petstore-change-namespace/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-change-namespace/_expected.d.ts
@@ -13,13 +13,22 @@ declare namespace Test {
             export type Limit = number; // int32
             export type Tags = string[];
         }
+        export interface PathParameters {
+            id: Test.PetStore.Parameters.Id; // int64
+        }
         export interface Pet {
             name: string;
             tag?: string;
             id: number; // int64
         }
+        export interface QueryParameters {
+            tags?: Test.PetStore.Parameters.Limit;
+            limit?: Test.PetStore.Parameters.Limit; // int32
+        }
+        export type RequestBody = Test.PetStore.NewPet;
         namespace Responses {
-            export type $200 = Test.PetStore.Pet[];
+            export type $200 = Test.PetStore.Pet;
+            export type Default = Test.PetStore.Error;
         }
     }
 }

--- a/test/snapshots/openapi-v3/petstore-change-namespace/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-change-namespace/_expected.d.ts
@@ -22,7 +22,7 @@ declare namespace Test {
             id: number; // int64
         }
         export interface QueryParameters {
-            tags?: Test.PetStore.Parameters.Limit;
+            tags?: Test.PetStore.Parameters.Tags;
             limit?: Test.PetStore.Parameters.Limit; // int32
         }
         export type RequestBody = Test.PetStore.NewPet;

--- a/test/snapshots/openapi-v3/petstore-no-namespace/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-no-namespace/_expected.d.ts
@@ -11,11 +11,20 @@ declare namespace Parameters {
     export type Limit = number; // int32
     export type Tags = string[];
 }
+declare interface PathParameters {
+    id: Parameters.Id; // int64
+}
 declare interface Pet {
     name: string;
     tag?: string;
     id: number; // int64
 }
+declare interface QueryParameters {
+    tags?: Parameters.Tags;
+    limit?: Parameters.Limit; // int32
+}
+declare type RequestBody = NewPet;
 declare namespace Responses {
-    export type $200 = Pet[];
+    export type $200 = Pet;
+    export type Default = Error;
 }

--- a/test/snapshots/openapi-v3/petstore-no-namespace/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-no-namespace/_expected.d.ts
@@ -1,28 +1,21 @@
-declare namespace Delete {
-    namespace Parameters {
-        export type Id = number; // int64
-    }
-}
 declare interface Error {
     code: number; // int32
     message: string;
-}
-declare namespace Get {
-    namespace Parameters {
-        export type Id = number; // int64
-        export type Limit = number; // int32
-        export type Tags = string[];
-    }
-    namespace Responses {
-        export type $200 = Pet[];
-    }
 }
 declare interface NewPet {
     name: string;
     tag?: string;
 }
+declare namespace Parameters {
+    export type Id = number; // int64
+    export type Limit = number; // int32
+    export type Tags = string[];
+}
 declare interface Pet {
     name: string;
     tag?: string;
     id: number; // int64
+}
+declare namespace Responses {
+    export type $200 = Pet[];
 }

--- a/test/snapshots/openapi-v3/petstore-no-operation-id/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-no-operation-id/_expected.d.ts
@@ -1,0 +1,42 @@
+declare namespace Components {
+    namespace Schemas {
+        export interface Error {
+            code: number; // int32
+            message: string;
+        }
+        export interface NewPet {
+            name: string;
+            tag?: string;
+        }
+        export interface Pet {
+            name: string;
+            tag?: string;
+            id: number; // int64
+        }
+    }
+}
+declare namespace Paths {
+    namespace Pets {
+        namespace Get {
+            namespace Parameters {
+                export type Limit = number; // int32
+                export type Tags = string[];
+            }
+            namespace Responses {
+                export type $200 = Components.Schemas.Pet[];
+            }
+        }
+    }
+    namespace Pets$Id {
+        namespace Delete {
+            namespace Parameters {
+                export type Id = number; // int64
+            }
+        }
+        namespace Get {
+            namespace Parameters {
+                export type Id = number; // int64
+            }
+        }
+    }
+}

--- a/test/snapshots/openapi-v3/petstore-no-operation-id/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore-no-operation-id/_expected.d.ts
@@ -22,8 +22,20 @@ declare namespace Paths {
                 export type Limit = number; // int32
                 export type Tags = string[];
             }
+            export interface QueryParameters {
+                tags?: Parameters.Tags;
+                limit?: Parameters.Limit; // int32
+            }
             namespace Responses {
                 export type $200 = Components.Schemas.Pet[];
+                export type Default = Components.Schemas.Error;
+            }
+        }
+        namespace Post {
+            export type RequestBody = Components.Schemas.NewPet;
+            namespace Responses {
+                export type $200 = Components.Schemas.Pet;
+                export type Default = Components.Schemas.Error;
             }
         }
     }
@@ -32,10 +44,23 @@ declare namespace Paths {
             namespace Parameters {
                 export type Id = number; // int64
             }
+            export interface PathParameters {
+                id: Parameters.Id; // int64
+            }
+            namespace Responses {
+                export type Default = Components.Schemas.Error;
+            }
         }
         namespace Get {
             namespace Parameters {
                 export type Id = number; // int64
+            }
+            export interface PathParameters {
+                id: Parameters.Id; // int64
+            }
+            namespace Responses {
+                export type $200 = Components.Schemas.Pet;
+                export type Default = Components.Schemas.Error;
             }
         }
     }

--- a/test/snapshots/openapi-v3/petstore-no-operation-id/petstore-expanded.yaml
+++ b/test/snapshots/openapi-v3/petstore-no-operation-id/petstore-expanded.yaml
@@ -1,0 +1,150 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/test/snapshots/openapi-v3/petstore/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore/_expected.d.ts
@@ -16,14 +16,34 @@ declare namespace Components {
     }
 }
 declare namespace Paths {
+    namespace AddPet {
+        export type RequestBody = Components.Schemas.NewPet;
+        namespace Responses {
+            export type $200 = Components.Schemas.Pet;
+            export type Default = Components.Schemas.Error;
+        }
+    }
     namespace DeletePet {
         namespace Parameters {
             export type Id = number; // int64
+        }
+        export interface PathParameters {
+            id: Parameters.Id; // int64
+        }
+        namespace Responses {
+            export type Default = Components.Schemas.Error;
         }
     }
     namespace FindPetById {
         namespace Parameters {
             export type Id = number; // int64
+        }
+        export interface PathParameters {
+            id: Parameters.Id; // int64
+        }
+        namespace Responses {
+            export type $200 = Components.Schemas.Pet;
+            export type Default = Components.Schemas.Error;
         }
     }
     namespace FindPets {
@@ -31,8 +51,13 @@ declare namespace Paths {
             export type Limit = number; // int32
             export type Tags = string[];
         }
+        export interface QueryParameters {
+            tags?: Parameters.Tags;
+            limit?: Parameters.Limit; // int32
+        }
         namespace Responses {
             export type $200 = Components.Schemas.Pet[];
+            export type Default = Components.Schemas.Error;
         }
     }
 }

--- a/test/snapshots/openapi-v3/petstore/_expected.d.ts
+++ b/test/snapshots/openapi-v3/petstore/_expected.d.ts
@@ -16,27 +16,23 @@ declare namespace Components {
     }
 }
 declare namespace Paths {
-    namespace Pets {
-        namespace Get {
-            namespace Parameters {
-                export type Limit = number; // int32
-                export type Tags = string[];
-            }
-            namespace Responses {
-                export type $200 = Components.Schemas.Pet[];
-            }
+    namespace DeletePet {
+        namespace Parameters {
+            export type Id = number; // int64
         }
     }
-    namespace PetsId_ {
-        namespace Delete {
-            namespace Parameters {
-                export type Id = number; // int64
-            }
+    namespace FindPetById {
+        namespace Parameters {
+            export type Id = number; // int64
         }
-        namespace Get {
-            namespace Parameters {
-                export type Id = number; // int64
-            }
+    }
+    namespace FindPets {
+        namespace Parameters {
+            export type Limit = number; // int32
+            export type Tags = string[];
+        }
+        namespace Responses {
+            export type $200 = Components.Schemas.Pet[];
         }
     }
 }


### PR DESCRIPTION
for #304 

- [ ] The `Parameters` namespace should be changed to interface. And each types should be changed to property in interface.
- [x] Is PetsPetId_ changed to Pets$PetId better?
- [x] The namespace increases in proportion to the length of path. So I guess emit `operationId` better if it set in operation. The `operationId` is unique in all operations.