### PR TITLE
fix missing schema due to yaml references

### DIFF
--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -23,6 +23,8 @@ export interface NormalizedSchema extends Schema {
 }
 
 export function parseSchema(content: any, url?: string): Schema {
+    content = JSON.parse(JSON.stringify(content));
+
     const { type, openApiVersion } = selectSchemaType(content);
     if (url != null) {
         setId(type, content, url);

--- a/test/snapshot_test.ts
+++ b/test/snapshot_test.ts
@@ -32,10 +32,7 @@ describe('Snapshot testing', () => {
                 const contents = files.map((file) => ({
                     file,
                     content: fs.readFileSync(file, { encoding: 'utf-8' }),
-                })).map(({ file, content }) => {
-                    const json = parseFileContent(content, file);
-                    return JSON.parse(JSON.stringify(json));
-                });
+                })).map(({ file, content }) => parseFileContent(content, file));
                 const actual = await dtsgenerator({ contents, ...commandInput });
 
                 // When we do `UPDATE_SNAPSHOT=1 npm test`, update snapshot data.

--- a/test/snapshot_test.ts
+++ b/test/snapshot_test.ts
@@ -32,7 +32,10 @@ describe('Snapshot testing', () => {
                 const contents = files.map((file) => ({
                     file,
                     content: fs.readFileSync(file, { encoding: 'utf-8' }),
-                })).map(({ file, content }) => parseFileContent(content, file));
+                })).map(({ file, content }) => {
+                    const json = parseFileContent(content, file);
+                    return JSON.parse(JSON.stringify(json));
+                });
                 const actual = await dtsgenerator({ contents, ...commandInput });
 
                 // When we do `UPDATE_SNAPSHOT=1 npm test`, update snapshot data.

--- a/test/snapshots/openapi-v3/yaml-reference/_expected.d.ts
+++ b/test/snapshots/openapi-v3/yaml-reference/_expected.d.ts
@@ -1,0 +1,22 @@
+declare namespace Paths {
+    namespace A {
+        namespace Post {
+            namespace Parameters {
+                export type Aa = string;
+            }
+            export interface QueryParameters {
+                aa?: Parameters.Aa;
+            }
+        }
+    }
+    namespace B {
+        namespace Post {
+            namespace Parameters {
+                export type Aa = string;
+            }
+            export interface QueryParameters {
+                aa?: Parameters.Aa;
+            }
+        }
+    }
+}

--- a/test/snapshots/openapi-v3/yaml-reference/yaml-reference.yaml
+++ b/test/snapshots/openapi-v3/yaml-reference/yaml-reference.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+info:
+  title: Yaml references
+  version: v0.1
+paths:
+  /a: &ads-3.0
+    post:
+      description: a
+      parameters:
+        - name: aa
+          in: query
+          schema:
+            type: string
+      requestBody:
+        application/json:
+          type: object
+      responses:
+        200:
+          application/json:
+            type: object
+  /b: *ads-3.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
+    "typeRoots": ["node_modules/@types"],
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [


### PR DESCRIPTION
js-yaml apparently re-uses objects that are defined using the yaml reference
syntax. This causes dtsgenerator to miss generating the schema and subsequently
causes an error when looking for that schema.