### PR TITLE
handle nullable: true types

### DIFF
--- a/src/core/dtsGenerator.ts
+++ b/src/core/dtsGenerator.ts
@@ -230,7 +230,14 @@ export default class DtsGenerator {
         if (type == null) {
             this.convertor.outputPrimitiveTypeName(schema, 'any', terminate, outputOptional);
         } else if (typeof type === 'string') {
-            this.generateTypeName(schema, type, terminate, outputOptional);
+            if (schema.content.nullable) {
+                const types = [type, 'null'];
+                this.convertor.outputArrayedType(schema, types, (t) => {
+                    this.generateTypeName(schema, t, false, false);
+                }, terminate);
+            } else {
+                this.generateTypeName(schema, type, terminate, outputOptional);
+            }
         } else {
             const types = utils.reduceTypes(type);
             if (types.length <= 1) {

--- a/src/core/jsonSchemaDraft04.d.ts
+++ b/src/core/jsonSchemaDraft04.d.ts
@@ -11,6 +11,7 @@ declare namespace JsonSchemaOrg {
             description?: string;
             example?: string;
             default?: any;
+            nullable?: boolean;
             multipleOf?: number;
             maximum?: number;
             exclusiveMaximum?: boolean;

--- a/src/core/jsonSchemaDraft07.d.ts
+++ b/src/core/jsonSchemaDraft07.d.ts
@@ -8,6 +8,7 @@ declare namespace JsonSchemaOrg {
             title?: string;
             description?: string;
             default?: any;
+            nullable?: boolean;
             readOnly?: boolean;
             examples?: any[];
             multipleOf?: number;

--- a/test/snapshots/openapi-v3/nullable/_expected.d.ts
+++ b/test/snapshots/openapi-v3/nullable/_expected.d.ts
@@ -1,0 +1,7 @@
+declare namespace Components {
+    namespace Schemas {
+        export interface Nullable {
+            field?: string | null;
+        }
+    }
+}

--- a/test/snapshots/openapi-v3/nullable/nullable.yaml
+++ b/test/snapshots/openapi-v3/nullable/nullable.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+info:
+  title: nullabe types
+  version: v0.1
+components:
+  schemas:
+    nullable:
+      type: object
+      properties:
+        field:
+          type: string
+          nullable: true
+paths:
+  post:
+    requestBody:
+      application/json:
+        $ref: '#/components/schemas/nullable'
+    responses:
+      200:
+        application/json:
+          type: object

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,6 +63,7 @@
     "test"
   ],
   "exclude": [
+    "dist/",
     "example",
     "test/snapshots"
   ]


### PR DESCRIPTION
typescript considers

    field?: number

to be different from

    field?: number | null

It seems that dtsgenerator allows using 'null' and so its possible to create a nullable type with oneOf. However openapi3, the spec, does not understand 'null' so that makes working with other tools taking in openapi3 a bit hard 