### PR TITLE
fix: typename when the path is nested

### DIFF
--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -152,7 +152,10 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             return '#/' + paths.join('/');
         }
         function convertKeyToTypeName(key: string): string {
-            return normalizeTypeName(key.replace(/[\/}]/g, '').replace(/{/, '$'));
+            key = key.replace(/\/(.)/g, (_match, p1) => {
+                return p1.toUpperCase();
+            });
+            return normalizeTypeName(key.replace(/}/g, '').replace(/{/, '$'));
         }
         function setSubIdToAnyObject<T>(f: (t: T, keys: string[]) => void, obj: { [key: string]: T } | undefined, keys: string[]): void {
             if (obj == null) {


### PR DESCRIPTION
Hi @horiuchi 

Thank you for the great tool
It's really useful!!

but I want one thing to be fixed

When you convert the path like (pet/owner/{id}), the path will be converted like this
petowner$Id
sometimes it’s difficult to read...

So, I want the path to be converted like below
petOwner$Id

This PR is for that :)