### PR TITLE
Add type file to be converted to string

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -17,6 +17,8 @@ export function toTSType(type: string, debugSource?: any): string | undefined {
         case 'object':
         case 'array':
             return undefined;
+        case 'file':
+            return 'string';
         default:
             if (debugSource) {
                 debug(`toTSType: unknown type: ${JSON.stringify(debugSource, null, 2)}`);


### PR DESCRIPTION
Hi,
Added the case when in the schema file is a type file which is converted to string type in ts.
https://swagger.io/docs/specification/data-models/data-types/