### PR TITLE
Avoid error when using `responses` & `requestBodies` components

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/core/",
   "typings": "dist/core/index.d.ts",
   "scripts": {
+    "start": "npm run build -- --watch",
     "clean": "rimraf dist/ {src,test}/**/*.{js,js.map}",
     "build": "tsc -p ./tsconfig-build.json",
     "prepublishOnly": "npm run build",

--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -110,7 +110,7 @@ export default class ReferenceResolver {
         searchAllSubSchema(schema, (subSchema) => {
             this.addSchema(subSchema);
         }, (refId) => {
-            this.addReference(refId);
+            this.addReference(refId, getSubSchema(schema, refId.getJsonPointerHash(), refId));
         });
     }
 
@@ -128,10 +128,14 @@ export default class ReferenceResolver {
             }
         }
     }
-    private addReference(refId: SchemaId): void {
+    private addReference(refId: SchemaId, schema: Schema): void {
         if (!this.referenceCache.has(refId.getAbsoluteId())) {
             debug(` add reference: id=${refId.getAbsoluteId()}`);
-            this.referenceCache.set(refId.getAbsoluteId(), undefined);
+            if (/#\/components\/(responses|requestBodies)\//.test(refId.getJsonPointerHash())) {
+                this.referenceCache.set(refId.getAbsoluteId(), schema);
+            } else {
+                this.referenceCache.set(refId.getAbsoluteId(), undefined);
+            }
         }
     }
 

--- a/test/snapshots/openapi-v3/responses-resquestbodies/_expected.d.ts
+++ b/test/snapshots/openapi-v3/responses-resquestbodies/_expected.d.ts
@@ -1,0 +1,26 @@
+declare namespace Components {
+    namespace RequestBodies {
+        export type ResourceCreationRequest = Schemas.Resource;
+    }
+    namespace Responses {
+        export type $201Created = Schemas.Resource;
+        export type $400Invalid = Schemas.Error;
+    }
+    namespace Schemas {
+        export interface Error {
+            error?: string;
+        }
+        export interface Resource {
+            status?: string;
+        }
+    }
+}
+declare namespace Paths {
+    namespace CreateResource {
+        export type RequestBody = Components.RequestBodies.ResourceCreationRequest;
+        namespace Responses {
+            export type $200 = Components.Responses.$201Created;
+            export type $400 = Components.Responses.$400Invalid;
+        }
+    }
+}

--- a/test/snapshots/openapi-v3/responses-resquestbodies/responses-resquestbodies.yaml
+++ b/test/snapshots/openapi-v3/responses-resquestbodies/responses-resquestbodies.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.2
+
+info:
+  description: example with response & requestBobies components
+  title: test
+  version: 0.0.1
+
+paths:
+
+  /resources:
+    post:
+      operationId: createResource
+      summary: Create a resource
+      requestBody:
+        $ref: '#/components/requestBodies/ResourceCreationRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/201Created'
+        '400':
+          $ref: '#/components/responses/400Invalid'
+components:
+
+  requestBodies:
+    ResourceCreationRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Resource'
+
+  responses:
+    201Created:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Resource'
+    400Invalid:
+      description: Invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    Resource:
+      type: object
+      properties:
+        status:
+          type: string
+    Error:
+      type: object
+      properties:
+        error:
+          type: string


### PR DESCRIPTION
Hi,

I consistently got parsing errors:
```
The $ref targets root is not found: #/components/responses/xxx
The $ref targets root is not found: #/components/requestBodies/xxx
```
when my openAPI files contains `responses` & `requestBodies` components.

here is a patch that fix the issue and still pass all tests ;)

