### PR TITLE
Added a preProcessor option for modifying the input schema before generating

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,18 +13,17 @@ export interface Options extends Partial<WriteProcessorOptions> {
     inputUrls?: string[];
     typeNameConvertor?: TypeNameConvertor;
     namespaceName?: string;
-    preProcessor?: PreProcessor;
+    remoteSchemaPreProcessor?: PreProcessor;
 }
 
 export default async function dtsGenerator(options: Options): Promise<string> {
-    const { preProcessor } = options;
+    const { remoteSchemaPreProcessor } = options;
     const processor = new WriteProcessor(options);
-    const resolver = new ReferenceResolver(options.preProcessor);
+    const resolver = new ReferenceResolver(remoteSchemaPreProcessor);
     const convertor = new SchemaConvertor(processor, options.typeNameConvertor, options.namespaceName);
 
     if (options.contents != null) {
         options.contents
-            .map((content) => preProcessor ? preProcessor(content) : content)
             .map((content) => parseSchema(content))
             .forEach((schema) => resolver.registerSchema(schema));
     }

--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -11,11 +11,11 @@ export type PreProcessor = (fileContents: string) => string;
 export default class ReferenceResolver {
     private readonly schemaCache = new Map<string, Schema>();
     private readonly referenceCache = new Map<string, Schema | undefined>();
-    private preProcessor: PreProcessor = (body: string) => body;
+    private remoteSchemaPreProcessor: PreProcessor = (body: string) => body;
 
     constructor(preProcessor?: PreProcessor) {
       if (preProcessor) {
-        this.preProcessor = preProcessor;
+        this.remoteSchemaPreProcessor = preProcessor;
       }
     }
 
@@ -110,7 +110,7 @@ export default class ReferenceResolver {
             throw new Error(`Error on fetch from url(${url}): ${res.status}, ${body}`);
         }
 
-        const content = parseFileContent(this.preProcessor(body), url);
+        const content = parseFileContent(this.remoteSchemaPreProcessor(body), url);
         const schema = parseSchema(content, url);
         this.registerSchema(schema);
     }

--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -6,12 +6,12 @@ import SchemaId from './schemaId';
 
 const debug = Debug('dtsgen');
 
-export type PreProcessor = (fileContents: string) => string;
+export type PreProcessor = (fileContents: string) => Promise<string>;
 
 export default class ReferenceResolver {
     private readonly schemaCache = new Map<string, Schema>();
     private readonly referenceCache = new Map<string, Schema | undefined>();
-    private remoteSchemaPreProcessor: PreProcessor = (body: string) => body;
+    private remoteSchemaPreProcessor: PreProcessor = (body: string) => Promise.resolve(body);
 
     constructor(preProcessor?: PreProcessor) {
       if (typeof preProcessor === 'function') {
@@ -110,7 +110,7 @@ export default class ReferenceResolver {
             throw new Error(`Error on fetch from url(${url}): ${res.status}, ${body}`);
         }
 
-        const content = parseFileContent(this.remoteSchemaPreProcessor(body), url);
+        const content = parseFileContent(await this.remoteSchemaPreProcessor(body), url);
         const schema = parseSchema(content, url);
         this.registerSchema(schema);
     }

--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -14,7 +14,7 @@ export default class ReferenceResolver {
     private remoteSchemaPreProcessor: PreProcessor = (body: string) => body;
 
     constructor(preProcessor?: PreProcessor) {
-      if (preProcessor) {
+      if (typeof preProcessor === 'function') {
         this.remoteSchemaPreProcessor = preProcessor;
       }
     }


### PR DESCRIPTION
@horiuchi What are your thoughts on this feature? 
The use-case this solves is when you're pulling down a schema remotely, you or your team have no control over it, and the schema itself produces errors on generation. This would you allow you pass in a small function to patch the schema before running it through the generation process