### PR TITLE
refactor: use `export` when given empty namespace

### DIFF
--- a/src/core/schemaConvertor.ts
+++ b/src/core/schemaConvertor.ts
@@ -84,7 +84,7 @@ export default class SchemaConvertor {
 
     public startInterfaceNest(id: SchemaId): void {
         const processor = this.processor;
-        if (processor.indentLevel === 0) {
+        if (processor.indentLevel === 0 && this.ns) {
             processor.output('declare ');
         } else {
             processor.output('export ');
@@ -100,7 +100,7 @@ export default class SchemaConvertor {
 
     public outputExportType(id: SchemaId): void {
         const processor = this.processor;
-        if (processor.indentLevel === 0) {
+        if (processor.indentLevel === 0 && this.ns) {
             processor.output('declare ');
         } else {
             processor.output('export ');

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -25,7 +25,7 @@ describe('simple schema test', () => {
         };
         const result = await dtsgenerator({ contents: [schema] });
 
-        const expected = `declare interface NoNamespace {
+        const expected = `export interface NoNamespace {
 }
 `;
         assert.equal(result, expected, result);

--- a/test/snapshots/json-schema-draft-04/apimeta/_expected.d.ts
+++ b/test/snapshots/json-schema-draft-04/apimeta/_expected.d.ts
@@ -1,13 +1,13 @@
 /**
  * ApiBaseObject of a record
  */
-declare interface ApiBaseObject {
+export interface ApiBaseObject {
     first?: string;
 }
 /**
  * Metadata of a record
  */
-declare interface ApiMetadata {
+export interface ApiMetadata {
     serverOperation?: "I" | "U" | "D";
     test?: ApiBaseObject;
 }


### PR DESCRIPTION
Our use case is that we're generating a package with from the OpenAPI
and given `--namespace ''` the generated interfaces are declared and not
exported. We could specify a namespace instead and the namespace would
be declared and the interfaces exported, but then we would need to use
the `namespace.InterfaceName` syntax or use cumbersome imports like
`import InterfaceName = namespace.InterfaceName` or type definitions
like `type InterfaceName = namespace.InterfaceName` throught the code
base.

Right now, we can either add those imports/type definitions or we can
run `sed` on the generated TypeScript file to change `declare` to
`export` as a workaround.

So, when using with empty namespace, i.e. specifying `--namespace ''` on
the CLI the generated interfaces should be exported as well. This adds a
condition for such a case by simply checking if given namespace is
empty.