### PR TITLE
Handle nested schema 'allOf' keywords.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -374,6 +374,14 @@
       "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
       "dev": true
     },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -1205,6 +1213,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "imurmurhash": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cross-fetch": "^3.0.4",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
+    "https-proxy-agent": "^5.0.0",
     "js-yaml": "^3.13.1",
     "mkdirp": "^1.0.3",
     "tslib": "^1.11.1"

--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -94,11 +94,28 @@ export default class ReferenceResolver {
         }
         return;
     }
-
+    private noProxy(url: URL): boolean {
+        if (process.env.NO_PROXY) {
+            for (const domain of process.env.NO_PROXY.split(/[, ]+/)) {
+                if (url.hostname.endsWith(domain)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
     public async registerRemoteSchema(url: string): Promise<void> {
         const fetchOptions:any = {};
-        if (process.env.HTTP_PROXY) {
-            const proxyUrl = new URL(process.env.HTTP_PROXY);
+        const parsedUrl = new URL(url);
+        let proxyUrl;
+        if (!this.noProxy(parsedUrl)) {
+            if (parsedUrl.protocol === 'http:' && process.env.HTTP_PROXY) {
+                proxyUrl = new URL(process.env.HTTP_PROXY);
+            } else if (parsedUrl.protocol === 'https:' && process.env.HTTPS_PROXY) {
+                proxyUrl = new URL(process.env.HTTPS_PROXY);
+            }
+        }
+        if (proxyUrl) {
             const agentOptions:any = {};
             agentOptions.host = proxyUrl.hostname;
             agentOptions.port = proxyUrl.port;

--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -117,6 +117,7 @@ export default class ReferenceResolver {
         }
         if (proxyUrl) {
             const agentOptions:any = {};
+            agentOptions.protocol = proxyUrl.protocol;
             agentOptions.host = proxyUrl.hostname;
             agentOptions.port = proxyUrl.port;
             if (proxyUrl.username) {

--- a/test/nested_allof_test.ts
+++ b/test/nested_allof_test.ts
@@ -1,0 +1,134 @@
+import * as assert from 'assert';
+import dtsGenerator from '../src/core';
+
+describe('nested \'allOf\' test', () => {
+    it ('single \'allOf\' nesting schema', async () => {
+        const schema: JsonSchemaOrg.Draft07.Schema = {
+            $id: '/test/nested/allOf',
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        a: { type: 'string' }
+                    }
+                },
+                {
+                    type: 'object',
+                    allOf: [
+                        {
+                            type: 'object',
+                            properties: {
+                                b: { type: 'string' }
+                            }
+                        },
+                        {
+                            type: 'object',
+                            properties: {
+                                c: { type: 'string' }
+                            }
+                        },
+                    ]
+                }
+            ],
+            required: ['a', 'b', 'c'],
+        };
+        const result = await dtsGenerator({contents: [schema]});
+
+        const expected = `declare namespace Test {
+    namespace Nested {
+        export interface AllOf {
+            a: string;
+            b: string;
+            c: string;
+        }
+    }
+}
+`;
+        assert.equal(result, expected, 'Nested \'allOf\' definitions should result in all properties being included in the output interface.');
+    });
+    it ('multiple \'allOf\' nestings schema', async () => {
+        const schema: JsonSchemaOrg.Draft07.Schema = {
+            $id: '/test/nested/allOf',
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        a: { type: 'string' }
+                    }
+                },
+                {
+                    type: 'object',
+                    allOf: [
+                        {
+                            type: 'object',
+                            properties: {
+                                b: { type: 'string' }
+                            }
+                        },
+                        {
+                            type: 'object',
+                            allOf: [
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        c: { type: 'string' }
+                                    }
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        d: { type: 'string' }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            type: 'object',
+                            allOf: [
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        c: { type: 'string' }
+                                    }
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        e: { type: 'string' }
+                                    }
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        f: { type: 'string' }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            required: ['a', 'b', 'c', 'd', 'e', 'f'],
+        };
+        const result = await dtsGenerator({contents: [schema]});
+
+        const expected = `declare namespace Test {
+    namespace Nested {
+        export interface AllOf {
+            a: string;
+            b: string;
+            c: string;
+            d: string;
+            e: string;
+            f: string;
+        }
+    }
+}
+`;
+        assert.equal(result, expected, 'Nested \'allOf\' definitions should result in all properties being included in the output interface.');
+    });
+});


### PR DESCRIPTION
Currently, **dtsGenerator** will ignore nested **allOf** keywords.

i.e. The Schema:
```
    {
        $id: '/test/nested/allOf',
        $schema: 'http://json-schema.org/draft-07/schema#',
        type: 'object',
        allOf: [ {
                type: 'object',
                properties: { a: { type: 'string' } }
            }, {
                type: 'object',
                allOf: [
                    {
                        type: 'object',
                        properties: { b: { type: 'string' } }
                    },
                    {
                        type: 'object',
                        properties: { c: { type: 'string' } }
                    }
                ]
            } ],
        required: ['a', 'b', 'c']
    }
```
Will only generate:
```
    declare namespace Test {
        namespace Nested {
            export interface AllOf {
                a: string;
                // Missing 'b', 'c' properties.
            }
        }
    }
```
This commit adds changes to recursively scan for nested **allOf** keywords within the schema, and generate the properties associated with the nested elements.

The mocha unit test:
```
  test/nested_allof_test.ts
```
Is included to exemplify the problem, and test the solution.
  
---
Additionally, the:
```
   src/core/referenceResolver.ts 
```
file was modified to allow unit tests to be run behind a corporate firewall, by making the resolver 'HTTP proxy' aware via the **HTTP_PROXY** environment variable.
```