### PR TITLE
add external ref support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node": ">= 8.0"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^9.0.1",
     "commander": "^5.1.0",
     "cross-fetch": "^3.0.4",
     "debug": "^4.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
+import SwaggerParser from '@apidevtools/swagger-parser';
 import opts, { initialize } from './commandOptions';
 import dtsgenerator from './core';
 import { globFiles, parseFileContent } from './utils';
@@ -29,20 +30,8 @@ function readSchemaFromStdin(): Promise<any> {
 }
 async function readSchemasFromFile(pattern: string): Promise<any[]> {
     const files = await globFiles(pattern);
-    return Promise.all(files.map((file: string) => {
-        return new Promise((resolve, reject) => {
-            fs.readFile(file, { encoding: 'utf-8' }, (err: any, content: string) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    try {
-                        resolve(parseFileContent(content, file));
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            });
-        });
+    return Promise.all(files.map(async (file: string) => {
+        return await SwaggerParser.bundle(file)
     }));
 }
 


### PR DESCRIPTION
Unless I missed something, dtsgen does not currently support refs of the form

```
$ref: './path/to/doc.yaml#/path/to/SomeObject
```

I recently made a pr to add this to another library (oazapfts), so as I'm having some trouble with that library, I thought I would do a quick PR which does basically the same thing I did for that library.

I'm not necessarily suggesting this PR should be accepted as-is (although that's up to you). This is just enough for you to confirm it works, so we can discuss what would actually make the PR acceptable.

I _think_ this closes #321 . I'm not totally sure I understand all that guy's requirements w/r/t other directories, but this does resolve a ref like `$ref: './other-dir/extern.yaml#/PartnerInfo'`.
