### PR TITLE
Fixes ref to empty response causing an error (Error: test The $ref tarrgets root is not found: #/components/responses/created)

### DIFF
--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -269,9 +269,10 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             }
             if ('content' in body) {
                 setSubIdToMediaTypes(body.content, keys);
-            }
-            if ('$ref' in body) {
+            } else if ('$ref' in body) {
                 setSubId(body, keys);
+            } else {
+                setSubId({}, keys)
             }
         }
         const setSubIdToResponsesV3 = (responses: OpenApisOrg.V3.SchemaJson.Definitions.ResponsesOrReferences | undefined, keys: string[]) => setSubIdToAnyObject(setSubIdToResponseV3, responses, keys);
@@ -281,9 +282,10 @@ export function searchAllSubSchema(schema: Schema, onFoundSchema: (subSchema: Sc
             }
             if ('content' in response) {
                 setSubIdToMediaTypes(response.content, keys);
-            }
-            if ('$ref' in response) {
+            } else if ('$ref' in response) {
                 setSubId(response, keys);
+            } else {
+                setSubId({}, keys)
             }
         }
         function setSubIdToOperationV3(ops: OpenApisOrg.V3.SchemaJson.Definitions.Operation | undefined, keys: string[]): void {

--- a/test/snapshots/openapi-v3/empty_response/_expected.d.ts
+++ b/test/snapshots/openapi-v3/empty_response/_expected.d.ts
@@ -1,7 +1,20 @@
 declare namespace Components {
+    namespace Responses {
+        export type Created = any;
+    }
     namespace Schemas {
         export interface Object {
             id?: string;
+        }
+    }
+}
+declare namespace Paths {
+    namespace Create {
+        namespace Post {
+            export type RequestBody = Components.Schemas.Object;
+            namespace Responses {
+                export type $204 = Components.Responses.Created;
+            }
         }
     }
 }

--- a/test/snapshots/openapi-v3/empty_response/empty_response.yaml
+++ b/test/snapshots/openapi-v3/empty_response/empty_response.yaml
@@ -13,10 +13,13 @@ components:
     created:
       description: 'object created'
 paths:
-  post:
-    requestBody:
-      application/json:
-        $ref: '#/components/schemas/object'
-    responses:
-      204:
-        $ref: '#/components/responses/created'
+  "/Create":
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/object'
+      responses:
+        204:
+          $ref: '#/components/responses/created'


### PR DESCRIPTION
Since there was no "content" or "$ref", it didnt register as part of the schema which caused it to be unable to find the key. This PR assigns an empty object to the key.

This should of been caught by the test unit but the test unit contained an invalid configuration so it didnt catch anything at all. I fixed that too

Resolves the issue in the comment of https://github.com/horiuchi/dtsgenerator/issues/330#issuecomment-627499356 (that comment, not the issue, thats for something else)