### PR TITLE
Add support for nullable anyOf in OpenApi v3

### DIFF
--- a/src/core/dtsGenerator.ts
+++ b/src/core/dtsGenerator.ts
@@ -199,7 +199,10 @@ export default class DtsGenerator {
             }
             if (content.nullable) {
                 const type = content.type;
-                if (type == null) {
+                const anyOf = content.anyOf;
+                if (Array.isArray(anyOf)) {
+                    anyOf.push({ type: 'null' });
+                } else if (type == null) {
                     content.type = 'null';
                 } else if (!Array.isArray(type)) {
                     content.type = [type, 'null'];

--- a/test/snapshots/openapi-v3/nullable/_expected.d.ts
+++ b/test/snapshots/openapi-v3/nullable/_expected.d.ts
@@ -3,5 +3,14 @@ declare namespace Components {
         export interface Nullable {
             field?: string | null;
         }
+        export interface NullableAllOf {
+            field?: {
+                field?: string | null;
+                id: string; // uuid
+            } | null;
+        }
+        export interface NullableAnyOf {
+            field?: string | boolean | null;
+        }
     }
 }

--- a/test/snapshots/openapi-v3/nullable/nullable.yaml
+++ b/test/snapshots/openapi-v3/nullable/nullable.yaml
@@ -10,6 +10,29 @@ components:
         field:
           type: string
           nullable: true
+
+    nullableAllOf:
+      type: object
+      properties:
+        field:
+          allOf:
+            - $ref: '#/components/schemas/nullable'
+            - required:
+                - id
+              properties:
+                id:
+                  type: string
+                  format: uuid
+          nullable: true
+
+    nullableAnyOf:
+      type: object
+      properties:
+        field:
+          anyOf:
+            - type: string
+            - type: boolean
+          nullable: true
 paths:
   post:
     requestBody:


### PR DESCRIPTION
In the current version, when a schema has `anyOf` and `nullable: true`, it does not work as expected.

The expected behaviour is that the `null` type is appended, like the current behaviour for a `type` array.