### PR TITLE
fix(mergeSchema): add truthy check for value

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -69,7 +69,7 @@ export function mergeSchema(a: any, b: any): any {
         if (Array.isArray(value)) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             a[key] = (a[key] ?? []).concat(value);
-        } else if (typeof value === 'object') {
+        } else if (typeof value === 'object' && !!value) {
             a[key] = mergeSchema(a[key] || {}, value);
         } else {
             a[key] = value;


### PR DESCRIPTION
I ran into a bug and I believe it has to do with a missing truthy check.

```
TypeError: Cannot use 'in' operator to search for '$ref' in null
    at mergeSchema (/usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:47:31)
    at /usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:60:22
    at Array.forEach (<anonymous>)
    at mergeSchema (/usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:50:20)
    at /usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:60:22
    at Array.forEach (<anonymous>)
    at mergeSchema (/usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:50:20)
    at /usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:60:22
    at Array.forEach (<anonymous>)
    at Object.mergeSchema (/usr/local/lib/node_modules/dtsgenerator/dist/core/utils.js:50:20)
```

I checked the value of `value` and it was `null` but the if statement still allows it through.

\*Shakes fist at javascript\*

There may be a bigger underlying issue but this quick fix works for me.

Thanks for the great lib!