### PR TITLE
fix: nested `oneOf` & `anyOf` keywords

### DIFF
--- a/src/core/dtsGenerator.ts
+++ b/src/core/dtsGenerator.ts
@@ -412,19 +412,23 @@ export default class DtsGenerator {
             );
         }
         if (content.anyOf) {
+            const mergeContent = Object.assign({}, content);
+            delete mergeContent.anyOf;
             return this.generateArrayedType(
                 schema,
                 content.anyOf,
-                Object.assign({}, content, { anyOf: undefined }),
+                mergeContent,
                 '/anyOf/',
                 terminate
             );
         }
         if (content.oneOf) {
+            const mergeContent = Object.assign({}, content);
+            delete mergeContent.oneOf;
             return this.generateArrayedType(
                 schema,
                 content.oneOf,
-                Object.assign({}, content, { oneOf: undefined }),
+                mergeContent,
                 '/oneOf/',
                 terminate
             );

--- a/test/nested_oneof_test.ts
+++ b/test/nested_oneof_test.ts
@@ -54,4 +54,156 @@ describe("nested 'oneOf' test", () => {
             "Nested 'oneOf' definitions should result in all properties being included in the output interface."
         );
     });
+
+    it("multiple 'oneOf' nestings schema", async () => {
+        const schema: JsonSchemaDraft07.Schema = {
+            $id: '/test/nested/oneOf',
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            oneOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        a: { type: 'string' },
+                    },
+                },
+                {
+                    type: 'object',
+                    oneOf: [
+                        {
+                            type: 'object',
+                            properties: {
+                                b: { type: 'string' },
+                            },
+                        },
+                        {
+                            type: 'object',
+                            oneOf: [
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        c: { type: 'string' },
+                                    },
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        d: { type: 'string' },
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            type: 'object',
+                            oneOf: [
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        c: { type: 'string' },
+                                    },
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        e: { type: 'string' },
+                                    },
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        f: { type: 'string' },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        const result = await dtsGenerator({ contents: [parseSchema(schema)] });
+
+        const expected = `declare namespace Test {
+    namespace Nested {
+        export type OneOf = {
+            a?: string;
+        } | ({
+            b?: string;
+        } | ({
+            c?: string;
+        } | {
+            d?: string;
+        }) | ({
+            c?: string;
+        } | {
+            e?: string;
+        } | {
+            f?: string;
+        }));
+    }
+}
+`;
+        assert.strictEqual(
+            result,
+            expected,
+            "Nested 'oneOf' definitions should result in all properties being included in the output interface."
+        );
+    });
+
+    it("refed 'oneOf' nested schema", async () => {
+        const schema: JsonSchemaDraft07.Schema = {
+            $id: '/test/nested/oneOf',
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            definitions: {
+                A: {
+                    properties: {
+                        s: {
+                            oneOf: [
+                                {
+                                    type: 'string',
+                                },
+                            ],
+                        },
+                    },
+                },
+                B: {
+                    properties: {
+                        ref: {
+                            oneOf: [
+                                {
+                                    $ref: '#/definitions/A',
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+            properties: {
+                bref: {
+                    $ref: '#/definitions/B',
+                },
+            },
+        };
+        const result = await dtsGenerator({ contents: [parseSchema(schema)] });
+
+        const expected = `declare namespace Test {
+    namespace Nested {
+        export interface OneOf {
+            bref?: OneOf.Definitions.B;
+        }
+        namespace OneOf {
+            namespace Definitions {
+                export interface A {
+                    s?: string;
+                }
+                export interface B {
+                    ref?: A;
+                }
+            }
+        }
+    }
+}
+`;
+        assert.strictEqual(result, expected);
+    });
 });

--- a/test/nested_oneof_test.ts
+++ b/test/nested_oneof_test.ts
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import dtsGenerator, { parseSchema } from '../src/core';
+import { JsonSchemaDraft07 } from '../src/core/jsonSchemaDraft07';
+
+describe("nested 'oneOf' test", () => {
+    it("single 'oneOf' nesting schema", async () => {
+        const schema: JsonSchemaDraft07.Schema = {
+            $id: '/test/nested/oneOf',
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            oneOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        a: { type: 'string' },
+                    },
+                },
+                {
+                    type: 'object',
+                    oneOf: [
+                        {
+                            type: 'object',
+                            properties: {
+                                b: { type: 'string' },
+                            },
+                        },
+                        {
+                            type: 'object',
+                            properties: {
+                                c: { type: 'string' },
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        const result = await dtsGenerator({ contents: [parseSchema(schema)] });
+
+        const expected = `declare namespace Test {
+    namespace Nested {
+        export type OneOf = {
+            a?: string;
+        } | ({
+            b?: string;
+        } | {
+            c?: string;
+        });
+    }
+}
+`;
+        assert.strictEqual(
+            result,
+            expected,
+            "Nested 'oneOf' definitions should result in all properties being included in the output interface."
+        );
+    });
+});


### PR DESCRIPTION
fixes #487