### PR TITLE
Support vendor media types (allow periods in application/*+json)

### DIFF
--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -353,7 +353,7 @@ export function searchAllSubSchema(
             }
             for (const mime of Object.keys(types)) {
                 if (
-                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_]+\+)?json)$|^application\/octet-stream$|^multipart\/form-data$/.test(
+                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)$|^application\/octet-stream$|^multipart\/form-data$/.test(
                         mime
                     )
                 ) {

--- a/test/snapshots/openapi-v3/support-media-type/_expected.d.ts
+++ b/test/snapshots/openapi-v3/support-media-type/_expected.d.ts
@@ -27,6 +27,14 @@ declare namespace Components {
     }
 }
 declare namespace Paths {
+    namespace FourthPath {
+        namespace Post {
+            export type RequestBody = Components.Schemas.Request;
+            namespace Responses {
+                export type $200 = Components.Responses.$200ReturnData;
+            }
+        }
+    }
     namespace Path {
         namespace Post {
             namespace Parameters {

--- a/test/snapshots/openapi-v3/support-media-type/example.yaml
+++ b/test/snapshots/openapi-v3/support-media-type/example.yaml
@@ -46,6 +46,18 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/200_ReturnData'
+  # Vendor media types.
+  /fourth-path:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/vnd.company.v1+json:
+            schema:
+              $ref: '#/components/schemas/Request'
+      responses:
+        200:
+          $ref: '#/components/responses/200_ReturnData'
 components:
   schemas:
     Request:


### PR DESCRIPTION
Without this, the following media types are not accepted:

- application/vnd.github+json
- application/vnd.github.v3+json
- application/vnd.github.v3.raw+json
- application/vnd.github.v3.text+json
- application/vnd.github.v3.html+json
- application/vnd.github.v3.full+json