### PR TITLE
Fix: support int keyword in conversion - int: number

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -18,6 +18,7 @@ export function toTSType(
             return ts.SyntaxKind.AnyKeyword;
         case 'boolean':
             return ts.SyntaxKind.BooleanKeyword;
+        case 'int':
         case 'integer':
             return ts.SyntaxKind.NumberKeyword;
         case 'null':


### PR DESCRIPTION
We have found using the repo that our code fails as `int` is not a supported word, as this is such a small line of code, can we have this feature added?

there's doesn't seem to be any tests for this, let me know if there are other pieces of code you would like me to update