### PR TITLE
feat: make PluginContext::inputSchemas an IterableIterator

### DIFF
--- a/src/core/referenceResolver.ts
+++ b/src/core/referenceResolver.ts
@@ -21,7 +21,7 @@ export default class ReferenceResolver {
     public getAllRegisteredSchema(): IterableIterator<Schema> {
         return this.schemaCache.values();
     }
-    public getAllRegisteredIdAndSchema(): Iterator<[string, Schema]> {
+    public getAllRegisteredIdAndSchema(): IterableIterator<[string, Schema]> {
         return this.schemaCache.entries();
     }
 

--- a/src/core/type.ts
+++ b/src/core/type.ts
@@ -114,7 +114,7 @@ function deepCopy(obj: any): any {
 
 export interface PluginContext {
     option: boolean | Record<string, unknown>;
-    inputSchemas: Iterator<[string, Schema]>;
+    inputSchemas: IterableIterator<[string, Schema]>;
 }
 
 export type PreProcessHandler = (contents: Schema[]) => Schema[];


### PR DESCRIPTION
The `ReferenceResolver::getAllRegisteredIdAndSchema` return type and by extension the `PluginContext::inputSchemas` type are `Iterators` which means they cannot be used in `for..of` or `Array::from`. This makes writing plugins a little more clunky than is ideal.

As `Map::entries` returns an `IterableIterator` (which can be used in the aforementioned contexts) we could use that type for the above function/fields and make them easier to work with.