### PR TITLE
feat: support mobile wallet media types

### DIFF
--- a/SupportedFeatures.md
+++ b/SupportedFeatures.md
@@ -112,5 +112,7 @@ The base JSON Schema version is Draft-07
 - `application/x-www-form-urlencoded`
 - `application/*+json`
 - `application/octet-stream`
+- `application/jwt`
+- `application/vnd.apple.pkpass`
 - `multipart/form-data`
 - `text/*`

--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -379,7 +379,7 @@ export function searchAllSubSchema(
             }
             for (const mime of Object.keys(types)) {
                 if (
-                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)$|^application\/octet-stream$|^multipart\/form-data$/.test(
+                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)$|^application\/octet-stream$|^application\/jwt$|^application\/vnd.apple.pkpass$|^multipart\/form-data$/.test(
                         mime
                     )
                 ) {

--- a/test/snapshots/openapi-v3/support-media-type/_expected.d.ts
+++ b/test/snapshots/openapi-v3/support-media-type/_expected.d.ts
@@ -5,6 +5,7 @@ declare namespace Components {
     }
     namespace Responses {
         export type $200ReturnData = Schemas.Data[];
+        export type $200ReturnString = string;
         export type $400BadRequest = Schemas.Error;
         export type $403Forbidden = Schemas.Error;
         export type $500Error = Schemas.Error;
@@ -27,6 +28,13 @@ declare namespace Components {
     }
 }
 declare namespace Paths {
+    namespace FifthPath {
+        namespace Get {
+            namespace Responses {
+                export type $200 = Components.Responses.$200ReturnString;
+            }
+        }
+    }
     namespace FourthPath {
         namespace Post {
             export type RequestBody = Components.Schemas.Request;

--- a/test/snapshots/openapi-v3/support-media-type/example.yaml
+++ b/test/snapshots/openapi-v3/support-media-type/example.yaml
@@ -58,6 +58,12 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/200_ReturnData'
+  # String-like media types.
+  /fifth-path:
+    get:
+      responses:
+        200:
+          $ref: '#/components/responses/200_ReturnString'
 components:
   schemas:
     Request:
@@ -97,6 +103,15 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Data'
+    200_ReturnString:
+      content:
+        application/jwt:
+          schema:
+            type: string
+        application/vnd.apple.pkpass:
+          schema:
+            type: string
+            format: binary
     400_BadRequest:
       content:
         application/problem+json:


### PR DESCRIPTION
I'm working with an API that sends mobile wallet passes, and `dtsgenerator` throws an error on that part of the schema. This adds support for `application/vnd.apple.pkpass` (Apple Pay) and `application/jwt` (Google Pay, among other uses). Both are typed as strings.
