### PR TITLE
Fix handling of stdin option

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,7 +109,13 @@ export function readConfig(options: CommandOptions): Partial<Config> {
     } else if (pc.input.urls == null) {
         pc.input.urls = [];
     }
-    pc.input.stdin = options.isReadFromStdin();
+    if (options.stdin != null) {
+        pc.input.stdin = options.stdin;
+    } else {
+        pc.input.stdin =
+            pc.input.stdin ||
+            (pc.input.files.length === 0 && pc.input.urls.length === 0);
+    }
 
     if (options.out != null) {
         pc.outputFile = options.out;

--- a/test/utils_test.ts
+++ b/test/utils_test.ts
@@ -146,5 +146,31 @@ describe('root utils test', () => {
                 plugins: {},
             });
         });
+
+        describe('setting `stdin` option correctly', () => {
+            it('prioritizes value from command line', () => {
+                const path = __dirname + '/test_config.json';
+                const options = new CommandOptions();
+                options.configFile = path;
+                options.stdin = false;
+
+                const actual = readConfig(options);
+                assert.equal(actual.input?.stdin, false);
+            });
+
+            it('defaults to `true` when its not set, but also no urls of files are set', () => {
+                const options = new CommandOptions();
+
+                const actual = readConfig(options);
+                assert.deepEqual(actual, {
+                    input: {
+                        files: [],
+                        urls: [],
+                        stdin: true,
+                    },
+                    outputAST: false,
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Hi @horiuchi!

While trying to generate types for a remote swagger spec, I ran into a small bug.

I was using this configuration file:
```
{
  "input": {
    "urls": ["https://example.com/swagger.json"]
  },
  "outputFile": "example.d.ts"
}
```
and I ran the command:
```
dtsgen -c dtsgen.json
```

I noticed that `stdin` was always set to `true`, because its value is always determined by the command line options, and it does not look at possible `files` and `urls` options from the config file.

This PR updates the logic just a little, so it takes the value from the command line if it is there, and otherwise looks at the determined `files` and `urls` arrays.