### PR TITLE
support for <application/json; ....> media types

### DIFF
--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -383,7 +383,7 @@ export function searchAllSubSchema(
             }
             for (const mime of Object.keys(types)) {
                 if (
-                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)|^application\/octet-stream$|^application\/jwt$|^application\/vnd.apple.pkpass$|^multipart\/form-data$|^image\//.test(
+                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)$|^application\/json;|^application\/octet-stream$|^application\/jwt$|^application\/vnd.apple.pkpass$|^multipart\/form-data$|^image\//.test(
                         mime
                     )
                 ) {

--- a/src/core/jsonSchema.ts
+++ b/src/core/jsonSchema.ts
@@ -383,7 +383,7 @@ export function searchAllSubSchema(
             }
             for (const mime of Object.keys(types)) {
                 if (
-                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)$|^application\/octet-stream$|^application\/jwt$|^application\/vnd.apple.pkpass$|^multipart\/form-data$|^image\//.test(
+                    /^text\/|^(?:application\/x-www-form-urlencoded$|^application\/([a-z0-9-_.]+\+)?json)|^application\/octet-stream$|^application\/jwt$|^application\/vnd.apple.pkpass$|^multipart\/form-data$|^image\//.test(
                         mime
                     )
                 ) {


### PR DESCRIPTION
some [Specs](https://dataaccess.scania.com/rfms4/swagger/v4.0.0/swagger.json) ( ![](https://validator.swagger.io/validator?url=https%3A%2F%2Fdataaccess.scania.com%2Frfms4%2Fswagger%2Fv4.0.0%2Fswagger.json) ) include compound media type values, such as: `"application/json; rfms=vehiclestatuses.v4.0; scania=vehiclestatuses.v1":`
API treats this as `application/json`. Follow up values are indicator for API to return extra information.
This fix allows "application/json" media type to accept follow-up values
