### PR TITLE
Add support for additionalProperties: false on empty objects

### DIFF
--- a/src/core/dtsGenerator.ts
+++ b/src/core/dtsGenerator.ts
@@ -366,6 +366,15 @@ export default class DtsGenerator {
                 )
             );
         }
+        if (result.length === 0 && content.additionalProperties === false) {
+            result.push(
+                ast.buildIndexSignatureNode(
+                    'name',
+                    ast.buildStringKeyword(),
+                    ast.buildNeverKeyword()
+                )
+            );
+        }
         return result;
     }
     private generateTypeProperty(

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -397,6 +397,28 @@ describe('simple schema test', () => {
 `;
         assert.strictEqual(result, expected, result);
     });
+    it('empty no additionalProperties schema', async () => {
+        const schema: JsonSchemaDraft04.Schema = {
+            id: 'test/root/empty_object',
+            description: 'This is an empty object schema',
+            type: 'object',
+            additionalProperties: false,
+        };
+        const result = await dtsgenerator({ contents: [parseSchema(schema)] });
+
+        const expected = `declare namespace Test {
+    namespace Root {
+        /**
+         * This is an empty object schema
+         */
+        export interface EmptyObject {
+            [name: string]: never;
+        }
+    }
+}
+`;
+        assert.strictEqual(result, expected, result);
+    });
     it('root any schema', async () => {
         const schema: JsonSchemaDraft04.Schema = {
             id: 'test/root/root_any',


### PR DESCRIPTION
Fix https://github.com/horiuchi/dtsgenerator/issues/525

For a schema with:
```yaml
type: object
additionalProperties: false
```

The generated TS definition should be:
```typescript
{
  [key: string]: never
}
```
to ensure that the object contains no properties at all
